### PR TITLE
fix: add --history-limit option to data fresh command

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -675,7 +675,13 @@ def data_reset(keep_config: bool):
 @data.command("fresh")
 @click.option("--days-back", default=30, help="Number of days to fetch")
 @click.option("--use-mock", is_flag=True, help="Use mock data instead of Azure DevOps")
-def data_fresh(days_back: int, use_mock: bool):
+@click.option(
+    "--history-limit",
+    default=None,
+    type=int,
+    help="Limit number of state history entries per work item for faster testing",
+)
+def data_fresh(days_back: int, use_mock: bool, history_limit: Optional[int]):
     """Start fresh: reset data and fetch new."""
     try:
         console.print("[cyan]🔄 Starting fresh data load...[/cyan]")
@@ -692,7 +698,7 @@ def data_fresh(days_back: int, use_mock: bool):
             console.print(
                 f"[yellow]Fetching fresh data for last {days_back} days...[/yellow]"
             )
-            ctx.invoke(fetch, days_back=days_back, save_last_run=True)
+            ctx.invoke(fetch, days_back=days_back, save_last_run=True, history_limit=history_limit)
             ctx.invoke(calculate)
 
         console.print("[green]✓ Fresh data load complete![/green]")


### PR DESCRIPTION
##·Summary␊
Fixes·the·error:·`No·such·option:·--history-limit`·when·running·the·`data·fresh`·command·with·the·`--history-limit`·parameter.␊
␊
##·Changes␊
-·\u{2705}·Add·`--history-limit`·option·to·`data·fresh`·command·decorator␊
-·\u{2705}·Update·function·signature·to·accept·`history_limit`·parameter··␊
-·\u{2705}·Pass·`history_limit`·parameter·through·to·`fetch`·command·invocation␊
␊
##·Test·plan␊
-·[x]·Verify·the·option·is·properly·defined·in·the·command␊
-·[x]·Confirm·parameter·is·passed·through·to·underlying·fetch·command␊
-·[·]·Test·the·command·runs·without·the·"No·such·option"·error␊
␊
\u{1f916}·Generated·with·[Claude·Code](https://claude.ai/code)␊